### PR TITLE
Cache RocksDB and gRPC compilation products

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: cpp
 os: linux
 dist: trusty
 sudo: required
+
+cache:
+   directories:
+     - $HOME/deps
+
 addons:
    apt:
      sources:
@@ -28,11 +33,15 @@ before_install:
   - ./install_crypto_tk_deps.sh
   - ./install_grpc.sh
   - ./install_rocksdb.sh
+  - PATH=$PATH:$HOME/deps/bin
+  - echo $CPATH
+  - echo $LD_LIBRARY_PATH
+  - echo $PATH
   - (cd third_party/crypto; scons lib static_relic=1)
   - (cd third_party/db-parser; scons lib)
   
   
 script:
-  - scons sophos
-  - scons diana
-  - scons janus
+  - scons config_file=ci_config.scons sophos
+  - scons config_file=ci_config.scons diana
+  - scons config_file=ci_config.scons janus

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,16 @@ env:
 
 before_install:
   - eval "${MATRIX_EVAL}"
-  - ./install_crypto_tk_deps.sh
-  - ./install_grpc.sh
-  - ./install_rocksdb.sh
-  - PATH=$PATH:$HOME/deps/bin
+  - INSTALL_DIR=$HOME/deps
+  - CPATH=$CPATH:$INSTALL_DIR/include
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INSTALL_DIR/lib
+  - PATH=$PATH:$INSTALL_DIR/bin
   - echo $CPATH
   - echo $LD_LIBRARY_PATH
   - echo $PATH
+  - ./install_crypto_tk_deps.sh
+  - ./install_grpc.sh
+  - ./install_rocksdb.sh
   - (cd third_party/crypto; scons lib static_relic=1)
   - (cd third_party/db-parser; scons lib)
   

--- a/SConstruct
+++ b/SConstruct
@@ -4,19 +4,26 @@ import os
 # AddOption('--prefix',dest='prefix',type='string', nargs=1, default='install',
     # action='store', metavar='DIR', help='installation prefix')
 
-env = Environment(tools=['default', 'protoc', 'grpc'])
+# env = Environment(tools=['default', 'protoc', 'grpc'])
 # def_env = DefaultEnvironment(PREFIX = GetOption('prefix'))
 
-try:
-    env.Append(ENV = {'TERM' : os.environ['TERM']}) # Keep our nice terminal environment (like colors ...)
-except:
-    print("Not running in a terminal")
+# try:
+#     env.Append(ENV = {'TERM' : os.environ['TERM']}) # Keep our nice terminal environment (like colors ...)
+# except:
+#     print("Not running in a terminal")
+
+env=Environment(ENV=os.environ, tools=['default', 'protoc', 'grpc'])
+
+print(env['ENV']['HOME'])
 
 if 'CC' in os.environ:
     env['CC']=os.environ['CC']
     
 if 'CXX' in os.environ:
     env['CXX']=os.environ['CXX']
+
+if 'CPATH' in os.environ:
+    env['CPATH']=os.environ['CPATH']
 
 root_dir = Dir('#').srcnode().abspath
 #
@@ -39,10 +46,13 @@ config['db-parser_lib'] = config['db-parser_lib_dir']  + "/lib"
 # config['verifiable_containers_include'] = config['verifiable_containers_lib_dir']  + "/include"
 # config['verifiable_containers_lib'] = config['verifiable_containers_lib_dir']  + "/lib"
 
-# if FindFile('config.scons', '.'):
-#     SConscript('config.scons', exports=['env','config'])
 
-env.Append(CCFLAGS = ['-fPIC','-Wall', '-march=native'])
+if 'config_file' in ARGUMENTS:
+    SConscript(ARGUMENTS['config_file'], exports=['env','config'])
+
+
+
+env.Append(CCFLAGS = ['-fPIC','-Wall', '-march=native', '-v'])
 env.Append(CXXFLAGS = ['-std=c++11'])
 env.Append(CPPPATH = ['/usr/local/include', config['cryto_include'], config['db-parser_include']])
 env.Append(LIBPATH = ['/usr/local/lib', config['cryto_lib'], config['db-parser_lib']])

--- a/SConstruct
+++ b/SConstruct
@@ -15,15 +15,13 @@ import os
 env=Environment(ENV=os.environ, tools=['default', 'protoc', 'grpc'])
 
 print(env['ENV']['HOME'])
+print(env['ENV']['PATH'])
 
 if 'CC' in os.environ:
     env['CC']=os.environ['CC']
     
 if 'CXX' in os.environ:
     env['CXX']=os.environ['CXX']
-
-if 'CPATH' in os.environ:
-    env['CPATH']=os.environ['CPATH']
 
 root_dir = Dir('#').srcnode().abspath
 #
@@ -52,7 +50,7 @@ if 'config_file' in ARGUMENTS:
 
 
 
-env.Append(CCFLAGS = ['-fPIC','-Wall', '-march=native', '-v'])
+env.Append(CCFLAGS = ['-fPIC','-Wall', '-march=native'])
 env.Append(CXXFLAGS = ['-std=c++11'])
 env.Append(CPPPATH = ['/usr/local/include', config['cryto_include'], config['db-parser_include']])
 env.Append(LIBPATH = ['/usr/local/lib', config['cryto_lib'], config['db-parser_lib']])

--- a/ci_config.scons
+++ b/ci_config.scons
@@ -1,0 +1,6 @@
+import os.path
+
+Import('*')
+
+env.Append(CPPPATH = [env['ENV']['HOME']+ "/deps/include"])
+env.Append(LIBPATH = [env['ENV']['HOME']+ "/deps/lib"])

--- a/install_grpc.sh
+++ b/install_grpc.sh
@@ -1,13 +1,33 @@
 #!/bin/sh
 set -ex
 
+if [ -d "$HOME/deps/include/google" ] && [ -d "$HOME/deps/include/grpc" ] && [ -d "$HOME/deps/include/grpc++" ]  && [ -f "$HOME/deps/lib/libprotobuf.a" ] && [ -f "$HOME/deps/lib/libgrpc.a" ]  && [ -f "$HOME/deps/bin/protoc" ]; then
+	
+	echo "gRPC is already installed"
+
+else
+	
+	echo "Install gRPC"
+	
+INSTALL_DIR=$HOME/deps
+
 git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 
 cd grpc
 git submodule update --init
-make -j2
 
-(cd third_party/protobuf; sudo make install;)
+# install protobuf
+# we have to do it that way because we need to cache the dependencies
+cd third_party/protobuf
 
+autoreconf -f -i -Wall,no-obsolete && ./configure --prefix=$INSTALL_DIR && make
 sudo make install
+sudo ldcondfig
+
+cd ../..
+
+
+make prefix=$INSTALL_DIR -j2
+sudo make prefix=$INSTALL_DIR install
 make clean
+fi

--- a/install_grpc.sh
+++ b/install_grpc.sh
@@ -16,18 +16,11 @@ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 cd grpc
 git submodule update --init
 
-# install protobuf
-# we have to do it that way because we need to cache the dependencies
+PROTOBUF_CONFIG_OPTS="--prefix=$INSTALL_DIR" make prefix=$INSTALL_DIR  -j2
+PROTOBUF_CONFIG_OPTS="--prefix=$INSTALL_DIR" sudo make prefix=$INSTALL_DIR install
+
 cd third_party/protobuf
-
-autoreconf -f -i -Wall,no-obsolete && ./configure --prefix=$INSTALL_DIR && make
 sudo make install
-sudo ldconfig
 
-cd ../..
-
-
-make prefix=$INSTALL_DIR -j2
-sudo make prefix=$INSTALL_DIR install
-make clean
+# make clean
 fi

--- a/install_grpc.sh
+++ b/install_grpc.sh
@@ -22,7 +22,7 @@ cd third_party/protobuf
 
 autoreconf -f -i -Wall,no-obsolete && ./configure --prefix=$INSTALL_DIR && make
 sudo make install
-sudo ldcondfig
+sudo ldconfig
 
 cd ../..
 

--- a/install_rocksdb.sh
+++ b/install_rocksdb.sh
@@ -4,6 +4,9 @@ set -ex
 if [ -d "$HOME/deps/include/rocksdb" ] && [ -f "$HOME/deps/lib/librocksdb.a" ]; then
 	echo "RocksDB is already installed"
 else
+	
+	echo "Install RocksDB"
+	
 	git clone https://github.com/facebook/rocksdb.git
 	cd rocksdb
 

--- a/install_rocksdb.sh
+++ b/install_rocksdb.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 set -ex
 
-git clone https://github.com/facebook/rocksdb.git
-cd rocksdb
+if [ -d "$HOME/deps/include/rocksdb" ] && [ -f "$HOME/deps/lib/librocksdb.a" ]; then
+	echo "RocksDB is already installed"
+else
+	git clone https://github.com/facebook/rocksdb.git
+	cd rocksdb
 
-make static_lib -j2
-sudo make install
-make clean
+	make INSTALL_PATH=$HOME/deps static_lib -j2
+	sudo make INSTALL_PATH=$HOME/deps install
+	make clean
+fi


### PR DESCRIPTION
For the moment, all the libraries, headers, and tools constructed during the before_install phase of the CI are not cached, and hence rebuilt every time. 

This is bad.

We should use Travis' cache to avoid that.